### PR TITLE
add observer in `componentWillMount` in nuclear component decorator

### DIFF
--- a/nuclearComponent.js
+++ b/nuclearComponent.js
@@ -42,7 +42,7 @@ function createComponent(Component, dataBindings) {
       return getState(this.context.reactor, dataBindings)
     },
 
-    componentDidMount: function() {
+    componentWillMount: function() {
       if (!dataBindings) {
         return
       }


### PR DESCRIPTION
@Sinewyk I updated my sample repo to demonstrate an issue I'm having with the `nuclearComponent` decorator https://github.com/dtothefp/nuclear-decorator/blob/master/app/components/modal/index.jsx.

This is a rough example of a modal with two cases
- opens from a user action such as clicking a button
- opens from an environmental state, such as cookie or query parameter.

The first situation works as expected, where as the state/component gets out of sync when doing the environmental state logic check in my modal component in `componentWillMount` or `componentDidMount`. Essentially from this SO post http://stackoverflow.com/questions/23734862/check-if-all-child-components-have-been-mounted/23744270#23744270 where you are attaching the change observer will not be called until after the lifecycle methods I want to hook into for initial environment checks have been fired. When `component.context.reactor.observe` is moved inside of `componentWillMount` for the decorator component, my modal works as expected.

In addition @colindresj proposes this change because "another reason for moving setState out of componentDidMount for the decorator is that did mount is not called on the server, making nuclear component not client-server universal"
