### PR TITLE
account for child context and default props

### DIFF
--- a/nuclearComponent.js
+++ b/nuclearComponent.js
@@ -31,9 +31,13 @@ function createComponent(Component, dataBindings) {
   var NuclearComponent = React.createClass({
     displayName: 'NuclearComponent(' + componentName + ')',
 
-    contextTypes: {
-      reactor: React.PropTypes.object.isRequired,
+    getDefaultProps: function() {
+      return objectAssign({}, Component.defaultProps)
     },
+
+    contextTypes: objectAssign({
+      reactor: React.PropTypes.object.isRequired
+    }, Component.contextTypes),
 
     getInitialState: function() {
       if (!dataBindings) {


### PR DESCRIPTION
1. the `provideReactor` decorator allows passing additional options for child context but the `nuclearComponent` decorator does not expose this context other than for the `reactor`. 
2. `defaultProps` are not exposed if iterating through `this.props.children` if the children use the use es6 React Component Class syntax `contetextTypes` and `defaultProps` are exposed as static methods and can be accessed in the `nuclearComponent`

Use case 1: 
- internal module has components as well as it's own nuclear stores and actions. These actions need the reactor in order to function. It is nice to have the Actions that have the reactor exposed to them passed down as context rather than having to pass the reactor to the actions at each use in the component.
- below will currently not work because on `line: 35` or `nuclearComonent` the context exposed to children is hardcoded to 

``` js
contextTypes: {
      reactor: React.PropTypes.object.isRequired,
},
```
- example

``` js
//my-module/Actions.js

export default function(reactor) {

  const action1 = function (initialValues) {
    reactor.dispatch('ACTION_1', {initialValues});
  };

  const action2 = function (data) {
    reactor.dispatch('ACTION_2', { data });
  };

  return {action1, action2};
}

//my-module/Input
@nuclearComponent({
  hasError: Getters.formErrors //these come from local module
})
export default class Input extends React.Component {
  static contextTypes = {
    Actions: React.PropTypes.object.isRequired
  };
  handleChange(e) {
    this.context.Actions.action1(e.target.value); //from parent context
  }
  render() {
    let classes = this.props.hasError ? 'errorr' : 'dope';

    <input className={classes} onChange={::this.handleChange} />
  }
}

//my-module/Form
@provideReactor({
  Actions. React.PropTypes.object.isRequired
})
@nuclearComponent({
  hasError: Getters.formErrors //these come from local module
})
export default class Form extends React.Component {
    static contextTypes = {
      Actions: React.PropTypes.object.isRequired
    };

   handleSubmit(e) {
     this.context.Actions.action2(/*data from form*/);  //from parent context
   }
   render() {
     let classes = this.props.hasError ? 'form-error' : 'dope-form';

     return (
          <form className={classes} onSubmit={::this.handleSubmit}>
             <Input type="text" name="dope" />
          </form>
     );
   }
}

// bootstrap
import makeModuleActions from 'my-module/Actions';
import Form from 'my-module/Form';
import reactor '../from/some/local/reactor/path';
import {formErrorStore as formErrors}  from 'my-module/Stores';

reactor.register({
  formErrors
});

React.render(<Form reactor={reactor} Actions={makeModuleActions(reactor)} />, document.body);
```

Use case 2:
- what if I want to do something dynamic with a components `this.props.children` and I need to have access to `defaultProps` on the children. In the current state of `nuclearComponent` if a child uses the `nuclearComponent` decorator those default props are obfuscated before the child component class is instantiated. 
- below will currently be problematic because the `nuclearDecorator` does not account for `defaultProps` and if I want to do something like gather initial form data such as `type` when iterating through children, and submit data to a `Store` during an initial lifecycle method, components created dynamically in `React.Children.map`/`React.cloneElement` loop will have initially undefined values for `type` in this case. 

``` js
//my-module/Input
@nuclearComponent({
  hasError: Getters.formErrors //these come from local module
})
export default class CheckBox extends React.Component {
  static defaultProps = {
    type: 'checkbox'
  };
  static contextTypes = {
    Actions: React.PropTypes.object.isRequired
  };
  handleChange(e) {
    this.context.Actions.action1(e.target.value); //from parent context
  }
  render() {
    let classes = this.props.hasError ? 'errorr' : 'dope';

    <input className={classes} onChange={::this.handleChange} />
  }
}

//my-module/Form
@nuclearComponent({
  hasError: Getters.formErrors //these come from local module
})
export default class Form extends React.Component {
    static contextTypes = {
      Actions: React.PropTypes.object.isRequired
    };

   constructor(props) {
     this.initalData = [];
   }

   handleSubmit(e) {
     this.context.Actions.action2(/*data from form*/);  //from parent context
   }
   render() {
     let classes = this.props.hasError ? 'form-error' : 'dope-form';

     return (
          <form className={classes} onSubmit={::this.handleSubmit}>
             {React.Children.map(this.props.children, (child, i) => {
                //if child component uses @nuclearComponent any default props not put directly on the 
                //jsx element will not be available
                this.initialData.push(child.props); //type will not be in this object
                React.cloneElement(child, {someNewProp: 'something'}); //child.props.type will be undefined
             }, this)}
          </form>
     );
   }
}

//external-application/form-with-checkbox
@provideReactor({
  Actions. React.PropTypes.object.isRequired
})

export default FormWithCheckbox extends React.Component {
  render() {
    return (
      <Form>
        <Input name="i_have_no_type_specified_but_default_to_checkbox" />
      </Form>
    );
  }
}

//bootstrap
import makeModuleActions from 'my-module/Actions';
import Form from 'my-module/FormWithCheckbox';
import reactor '../from/some/local/reactor/path';
import {formErrorStore as formErrors}  from 'my-module/Stores';

reactor.register({
  formErrors
});

React.render(<FormWithCheckbox reactor={reactor} Actions={makeModuleActions(reactor)} />, document.body);
```
