### PR TITLE
[WIP] Call setState on React components once per dispatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React addons for nuclear-js",
   "main": "build/index.js",
   "scripts": {
+    "babel:watch": "NODE_ENV=production babel src -w --out-dir build",
     "build": "scripts/build.sh",
     "prepublish": "npm run build",
     "test": "npm run lint && karma start --single-run",

--- a/src/connect.js
+++ b/src/connect.js
@@ -13,7 +13,7 @@ export default function connect(mapStateToProps) {
       constructor(props, context) {
         super(props, context)
         this.reactor = props.reactor || context.reactor
-        this.unsubscribeFns = []
+        this.unsubscribeFn = null
         this.updatePropMap(props)
       }
 
@@ -53,26 +53,26 @@ export default function connect(mapStateToProps) {
       }
 
       subscribe() {
-        let propMap = this.propMap
-        for (let key in propMap) {
-          const getter = propMap[key]
-          const unsubscribeFn = this.reactor.observe(getter, val => {
-            this.setState({
-              [key]: val,
-            })
-          })
+        const propMap = this.propMap
+        const keys = Object.keys(propMap)
+        const getters = keys.map(k => propMap[k])
 
-          this.unsubscribeFns.push(unsubscribeFn)
-        }
+        // Add a final function to the getter to aggregate results in an array
+        getters.push((...vals) => vals)
+
+        this.unsubscribeFn = this.reactor.observe(getters, (vals) => {
+          const newState = vals.reduce((state, val, i) => {
+            state[keys[i]] = val
+            return state
+          }, {})
+
+          this.setState(newState)
+        })
       }
 
       unsubscribe() {
-        if (this.unsubscribeFns.length === 0) {
-          return
-        }
-
-        while (this.unsubscribeFns.length > 0) {
-          this.unsubscribeFns.shift()()
+        if (this.unsubscribeFn) {
+          this.unsubscribeFn()
         }
       }
 

--- a/src/connect.js
+++ b/src/connect.js
@@ -41,8 +41,8 @@ export default function connect(mapStateToProps) {
       }
 
       updateState() {
-        let propMap = this.propMap
-        let stateToSet = {}
+        const propMap = this.propMap
+        const stateToSet = {}
 
         for (let key in propMap) {
           const getter = propMap[key]


### PR DESCRIPTION
This PR is incomplete and open for discussion. I updated `connect` to only call setState on the wrapped component once per dispatch. I haven't yet touched `nuclearMixin` as I wanted to get feedback first and see if this is a change you would be interested in, but I'd be happy to update that as well.

This relates directly to https://github.com/optimizely/nuclear-js/pull/195 and #13. Open to any feedback or suggestions.
